### PR TITLE
Fix test command which was calling mutt instead of neomutt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,5 @@ script:
   - brew install neomutt $FORMULA_VERSION --verbose
   - brew audit neomutt --strict
   - brew test neomutt
-  - mutt -D
 matrix:
   fast_finish: true

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -59,6 +59,6 @@ class Neomutt < Formula
   end
 
   test do
-    system bin/"mutt", "-D"
+    system bin/"neomutt", "-D"
   end
 end


### PR DESCRIPTION
`brew test` for the formula is failing because the wrong command is called. Even worse, if `mutt` is installed the test will deceptively pass.