### PR TITLE
Update neomutt.rb

### DIFF
--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -14,6 +14,8 @@ class Neomutt < Formula
   depends_on "gettext" => :build
   depends_on "docbook" => :build
   depends_on "docbook-xsl" => :build
+  depends_on "libxslt" => :build unless OS.mac?
+  depends_on "krb5" => :build unless OS.mac?
 
   depends_on "openssl"
   depends_on "tokyo-cabinet" => :recommended unless build.with?("lmdb")
@@ -31,7 +33,6 @@ class Neomutt < Formula
     args = %W[
       --prefix=#{prefix}
       --with-ssl=#{Formula["openssl"].opt_prefix}
-      --sasl
       --gss
       --disable-idn
     ]
@@ -40,6 +41,8 @@ class Neomutt < Formula
 
     # Neomutt-specific patches
     args << "--notmuch" if build.with? "notmuch-patch"
+    
+    args << "--sasl" if OS.linux?
 
     if build.with? "lmdb"
       args << "--lmdb"


### PR DESCRIPTION
With a stock install of linuxbrew, the configure step fails since it can't find xlstproc and krb5-config. Adding these as build dependencies allows the configure step to complete.

The sasl flag fails to find sasl/sasl.h, which is currently not provided by any linuxbrew packages to my knowledge. I had to remove the --sasl flag for the configure step to complete.